### PR TITLE
Prevent constant reindexing of same content

### DIFF
--- a/src/IndexerBase.php
+++ b/src/IndexerBase.php
@@ -54,8 +54,9 @@ abstract class IndexerBase implements SearchIndexingInterface {
     ]);
 
     $this->database->query('
-      INSERT IGNORE INTO {kifisearch_index} (entity_id, entity_type)
-      VALUES (:id, :type)', [
+      INSERT INTO {kifisearch_index} (entity_id, entity_type)
+      VALUES (:id, :type)
+      ON DUPLICATE KEY UPDATE reindex=0', [
       'id' => $document['id'],
       'type' => $document['entity_type'],
     ]);


### PR DESCRIPTION
This fixes the currently stuck search indexing in kirjastot.fi. There were some search API changes during the Drupal 8.8 upgrade and it's still a mystery why I got stuck in the first place, I guess that it would have something to do with the changes, although I was not able yet to pin the breaking change. Might be, because indexes never get cleared or some underlying change in Drupal's ORM (I still have no idea).

Original issue:
https://projektit.kirjastot.fi/issues/5955

Commit message:
---
After the Drupal 8.7.x -> 8.9.x, the search indexing got stuck indexing
the same content over and over again.
Toggle the 'reindex' value to to zero fixes to fix this.